### PR TITLE
Configurable kubernetes namespace

### DIFF
--- a/cmd/cube/main.go
+++ b/cmd/cube/main.go
@@ -102,6 +102,10 @@ func main() {
 				cli.BoolFlag{
 					Name: "skipSslValidation",
 				},
+				cli.StringFlag{
+					Name:  "namespace",
+					Usage: "name of the kubernetes cluster used for app staging",
+				},
 			},
 			Action: stagingCmd,
 		},

--- a/cmd/cube/main.go
+++ b/cmd/cube/main.go
@@ -72,6 +72,10 @@ func main() {
 					Name:  "config",
 					Usage: "Path to cube config file",
 				},
+				cli.StringFlag{
+					Name:  "namespace",
+					Usage: "name of the kubernetes cluster used for app staging",
+				},
 			},
 			Action: syncCmd,
 		},

--- a/cmd/cube/stager.go
+++ b/cmd/cube/stager.go
@@ -21,7 +21,10 @@ func stagingCmd(c *cli.Context) {
 	clientset, err := kubernetes.NewForConfig(config)
 	exitWithError(err)
 
-	taskDesirer := k8s.TaskDesirer{Client: clientset}
+	taskDesirer := k8s.TaskDesirer{
+		Config: k8s.JobConfig{Namespace: c.String("namespace")},
+		Client: clientset,
+	}
 
 	st8 := st8ger.St8ger{
 		taskDesirer,

--- a/cmd/cube/sync.go
+++ b/cmd/cube/sync.go
@@ -124,7 +124,7 @@ func setConfigFromCLI(c *cli.Context) *cube.SyncConfig {
 	return &cube.SyncConfig{
 		Properties: cube.SyncProperties{
 			KubeConfig:         c.String("kubeconfig"),
-			KubeNamespace:      "default",
+			KubeNamespace:      c.String("namespace"),
 			RegistryEndpoint:   "http://127.0.0.1:8080",
 			Backend:            c.String("backend"),
 			CcApi:              c.String("ccApi"),

--- a/cmd/cube/sync.go
+++ b/cmd/cube/sync.go
@@ -64,9 +64,14 @@ func syncCmd(c *cli.Context) {
 	log := lager.NewLogger("sync")
 	log.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
 
+	desirer := &k8s.Desirer{
+		KubeNamespace: conf.Properties.KubeNamespace,
+		Client:        clientset,
+	}
+
 	converger := sink.Converger{
 		Converter:   sink.ConvertFunc(sink.Convert),
-		Desirer:     &k8s.Desirer{Client: clientset},
+		Desirer:     desirer,
 		CfClient:    cfClient,
 		Client:      client,
 		Logger:      log,
@@ -119,6 +124,7 @@ func setConfigFromCLI(c *cli.Context) *cube.SyncConfig {
 	return &cube.SyncConfig{
 		Properties: cube.SyncProperties{
 			KubeConfig:         c.String("kubeconfig"),
+			KubeNamespace:      "default",
 			RegistryEndpoint:   "http://127.0.0.1:8080",
 			Backend:            c.String("backend"),
 			CcApi:              c.String("ccApi"),

--- a/k8s/desire_test.go
+++ b/k8s/desire_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/julz/cube/opi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/api/apps/v1beta1"
+	"k8s.io/api/core/v1"
 	av1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -17,9 +20,34 @@ import (
 // NOTE: this test requires a minikube to be set up and targeted in ~/.kube/config
 var _ = Describe("Desiring some LRPs", func() {
 	var (
-		client  *kubernetes.Clientset
-		desirer *k8s.Desirer
+		client    *kubernetes.Clientset
+		desirer   *k8s.Desirer
+		namespace string
+		lrps      []opi.LRP
 	)
+
+	namespaceExists := func(name string) bool {
+		_, err := client.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+		return err == nil
+	}
+
+	createNamespace := func(name string) {
+		namespaceSpec := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}
+
+		if _, err := client.CoreV1().Namespaces().Create(namespaceSpec); err != nil {
+			panic(err)
+		}
+	}
+
+	getLRPNames := func() []string {
+		names := []string{}
+		for _, lrp := range lrps {
+			names = append(names, lrp.Name)
+		}
+		return names
+	}
 
 	BeforeEach(func() {
 		config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(os.Getenv("HOME"), ".kube", "config"))
@@ -32,34 +60,70 @@ var _ = Describe("Desiring some LRPs", func() {
 			panic(err.Error())
 		}
 
-		desirer = &k8s.Desirer{Client: client}
-	})
-
-	It("Creates deployments for every LRP in the array", func() {
-		Expect(desirer.Desire(context.Background(), []opi.LRP{
+		namespace = "testing"
+		lrps = []opi.LRP{
 			{Name: "app0", Image: "busybox", TargetInstances: 1, Command: []string{""}},
 			{Name: "app1", Image: "busybox", TargetInstances: 3, Command: []string{""}},
-		})).To(Succeed())
-
-		deployments, err := client.AppsV1beta1().Deployments("default").List(av1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		Expect(deployments.Items).To(HaveLen(2))
-	})
-
-	It("creates services for every deployment", func() {
-		services, err := client.CoreV1().Services("default").List(av1.ListOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(services.Items).To(HaveLen(3)) //two deployments + default kubernetes service
-	})
-
-	It("Doesn't error when the deployment already exists", func() {
-		for i := 0; i < 2; i++ {
-			Expect(desirer.Desire(context.Background(), []opi.LRP{
-				{Name: "app0", Image: "busybox", TargetInstances: 1, Command: []string{""}},
-				{Name: "app1", Image: "busybox", TargetInstances: 3, Command: []string{""}},
-			})).To(Succeed())
 		}
+	})
+
+	JustBeforeEach(func() {
+		if !namespaceExists(namespace) {
+			createNamespace(namespace)
+		}
+
+		desirer = &k8s.Desirer{
+			KubeNamespace: namespace,
+			Client:        client,
+		}
+	})
+
+	AfterEach(func() {
+		for _, appName := range getLRPNames() {
+			if err := client.AppsV1beta1().Deployments(namespace).Delete(appName, &metav1.DeleteOptions{}); err != nil {
+				panic(err)
+			}
+
+			if err := client.CoreV1().Services(namespace).Delete(appName, &metav1.DeleteOptions{}); err != nil {
+				panic(err)
+			}
+		}
+	})
+
+	Context("When a LPP is desired", func() {
+
+		getDeploymentNames := func(deployments *v1beta1.DeploymentList) []string {
+			depNames := []string{}
+			for _, deployment := range deployments.Items {
+				depNames = append(depNames, deployment.ObjectMeta.Name)
+			}
+
+			return depNames
+		}
+
+		It("Creates deployments for every LRP in the array", func() {
+			Expect(desirer.Desire(context.Background(), lrps)).To(Succeed())
+
+			deployments, err := client.AppsV1beta1().Deployments(namespace).List(av1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(deployments.Items).To(HaveLen(len(lrps)))
+			Expect(getDeploymentNames(deployments)).To(ConsistOf(getLRPNames()))
+		})
+
+		It("creates services for every deployment", func() {
+			Expect(desirer.Desire(context.Background(), lrps)).To(Succeed())
+
+			services, err := client.CoreV1().Services(namespace).List(av1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(services.Items).To(HaveLen(len(lrps)))
+		})
+
+		It("Doesn't error when the deployment already exists", func() {
+			for i := 0; i < 2; i++ {
+				Expect(desirer.Desire(context.Background(), lrps)).To(Succeed())
+			}
+		})
 	})
 
 	PIt("Removes any LRPs in the namespace that are no longer desired", func() {

--- a/k8s/desiretask.go
+++ b/k8s/desiretask.go
@@ -19,11 +19,13 @@ type JobConfig struct {
 }
 
 type TaskDesirer struct {
+	Config JobConfig
 	Client *kubernetes.Clientset
 }
 
 func (d TaskDesirer) Desire(ctx context.Context, tasks []opi.Task) error {
-	jobs, err := d.Client.BatchV1().Jobs("default").List(av1.ListOptions{})
+	namespace := d.Config.Namespace
+	jobs, err := d.Client.BatchV1().Jobs(namespace).List(av1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -34,7 +36,7 @@ func (d TaskDesirer) Desire(ctx context.Context, tasks []opi.Task) error {
 	}
 
 	for _, task := range tasks {
-		if _, err := d.Client.BatchV1().Jobs("default").Create(toJob(task)); err != nil {
+		if _, err := d.Client.BatchV1().Jobs(namespace).Create(toJob(task)); err != nil {
 			// fixme: this should be a multi-error and deferred
 			return err
 		}
@@ -44,7 +46,8 @@ func (d TaskDesirer) Desire(ctx context.Context, tasks []opi.Task) error {
 }
 
 func (d *TaskDesirer) DeleteJob(job string) error {
-	return d.Client.BatchV1().Jobs("default").Delete(job, nil)
+	namespace := d.Config.Namespace
+	return d.Client.BatchV1().Jobs(namespace).Delete(job, nil)
 }
 
 func toJob(task opi.Task) *batch.Job {

--- a/k8s/desiretask_test.go
+++ b/k8s/desiretask_test.go
@@ -4,22 +4,50 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/julz/cube/k8s"
 	"github.com/julz/cube/opi"
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	bv1 "k8s.io/api/batch/v1"
 	av1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Desiretask", func() {
 	var (
-		client  *kubernetes.Clientset
-		desirer *k8s.TaskDesirer
+		client    *kubernetes.Clientset
+		desirer   *k8s.TaskDesirer
+		namespace string
+		tasks     []opi.Task
 	)
+
+	namespaceExists := func(name string) bool {
+		_, err := client.CoreV1().Namespaces().Get(namespace, av1.GetOptions{})
+		return err == nil
+	}
+
+	createNamespace := func(name string) {
+		namespaceSpec := &v1.Namespace{
+			ObjectMeta: av1.ObjectMeta{Name: name},
+		}
+
+		if _, err := client.CoreV1().Namespaces().Create(namespaceSpec); err != nil {
+			panic(err)
+		}
+	}
+
+	getTaskNames := func() []string {
+		names := []string{}
+		for _, task := range tasks {
+			names = append(names, task.Env["APP_ID"])
+		}
+		return names
+	}
 
 	BeforeEach(func() {
 		config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(os.Getenv("HOME"), ".kube", "config"))
@@ -32,21 +60,68 @@ var _ = Describe("Desiretask", func() {
 			panic(err.Error())
 		}
 
-		desirer = &k8s.TaskDesirer{Client: client}
+		namespace = "testing"
+		tasks = []opi.Task{
+			{Image: "pi", Command: []string{}, Env: map[string]string{"APP_ID": "guid0", "STAGING_GUID": "guid0"}},
+			{Image: "pi", Command: []string{}, Env: map[string]string{"APP_ID": "guid1", "STAGING_GUID": "guid1"}},
+		}
 	})
 
-	AfterEach(func() {
-		desirer.DeleteJob("guid")
+	JustBeforeEach(func() {
+		if !namespaceExists(namespace) {
+			createNamespace(namespace)
+		}
+
+		desirer = &k8s.TaskDesirer{
+			Config: k8s.JobConfig{Namespace: namespace},
+			Client: client,
+		}
 	})
 
-	It("creates jobs for every task in the array", func() {
-		Expect(desirer.Desire(context.Background(), []opi.Task{
-			{Image: "pi", Command: []string{}, Env: map[string]string{"APP_ID": "guid", "STAGING_GUID": "guid"}},
-		})).To(Succeed())
+	Context("When desiring some tasks", func() {
 
-		deployments, err := client.AppsV1beta1().Deployments("default").List(av1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		AfterEach(func() {
+			for _, jobName := range getTaskNames() {
+				if err := client.BatchV1().Jobs(namespace).Delete(jobName, &av1.DeleteOptions{}); err != nil {
+					panic(err)
+				}
+			}
+		})
 
-		Expect(deployments.Items).To(HaveLen(2))
+		getJobNames := func(jobs *bv1.JobList) []string {
+			jobNames := []string{}
+			for _, job := range jobs.Items {
+				jobNames = append(jobNames, job.ObjectMeta.Name)
+			}
+
+			return jobNames
+		}
+
+		It("creates jobs for every task in the array", func() {
+			Expect(desirer.Desire(context.Background(), tasks)).To(Succeed())
+
+			jobs, err := client.BatchV1().Jobs(namespace).List(av1.ListOptions{})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(jobs.Items).To(HaveLen(len(tasks)))
+			Expect(getJobNames(jobs)).To(ConsistOf(getTaskNames()))
+		})
 	})
+
+	Context("When trying to delete some tasks", func() {
+
+		It("deletes every task in the array", func() {
+			Expect(desirer.Desire(context.Background(), tasks)).To(Succeed())
+
+			for _, taskName := range getTaskNames() {
+				Expect(desirer.DeleteJob(taskName)).To(Succeed())
+			}
+			time.Sleep(1 * time.Second)
+
+			jobs, err := client.BatchV1().Jobs(namespace).List(av1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(jobs.Items).To(BeEmpty())
+		})
+	})
+
 })

--- a/models.go
+++ b/models.go
@@ -40,6 +40,7 @@ type SyncConfig struct {
 
 type SyncProperties struct {
 	KubeConfig         string `yaml:"kube_config"`
+	KubeNamespace      string `yaml:"kube_namespace"`
 	RegistryEndpoint   string `yaml:"registry_endpoint"`
 	CcApi              string `yaml:"api_endpoint"`
 	Backend            string `yaml:"backend"`


### PR DESCRIPTION
Maybe it would be better to mock all used k8s APIs and verify our interactions with them instead of relying on minikube? I am not sure how reliable minikube is &mdash; for example [on this line](https://github.com/gdankov/cube/blob/ac414ae40f46522810922b6a06bfb45defdd0531/k8s/desiretask_test.go#L119) i have to wait a second before getting all jobs, because jobs are not deleted immediately. One second sleep works on my minikube installation, but will it work on others as well? It would be easier to just verify the interaction.
This will also allow us to test all error conditions that are not currently covered.

Also, as a side note, maybe [DeleteJob](https://github.com/gdankov/cube/blob/ac414ae40f46522810922b6a06bfb45defdd0531/k8s/desiretask.go#L48) should be renamed to either `Delete` or `DeleteTask` because Job is a k8s abstraction, but `Desirer` interface works with Diego abstractions.

What do you think?